### PR TITLE
Register pools routes and handle team list input

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from db import db
 from routes.teams import teams_bp
 from routes.scores import scores_bp
 from routes.tournaments import tournaments_bp
+from routes.pools import pools_bp
 import os
 
 app = Flask(__name__)
@@ -30,6 +31,7 @@ with app.app_context():
 app.register_blueprint(teams_bp)
 app.register_blueprint(scores_bp)
 app.register_blueprint(tournaments_bp)
+app.register_blueprint(pools_bp)
 
 if __name__ == '__main__':
     import os

--- a/routes/teams.py
+++ b/routes/teams.py
@@ -16,13 +16,22 @@ def get_all_teams():  # Renommé de 'get_teams' à 'get_all_teams'
 @teams_bp.route('/api/teams', methods=['POST'])
 def create_team():  # Renommé de 'add_team' à 'create_team'
     try:
-        data = request.get_json()
-        if not data or not data.get('members'):
+        data = request.get_json() or {}
+        name = data.get('name')
+        members = data.get('members')
+
+        if not name or not members:
             return jsonify({'error': 'Invalid data'}), 400
 
+        # Allow members to be provided either as a string or a list
+        if isinstance(members, list):
+            members = ",".join(members)
+
         new_team = Team(
-            name=data.get('name', data['members']),
-            members=data['members']
+            name=name,
+            members=members,
+            email=data.get('email'),
+            phone=data.get('phone')
         )
 
         db.session.add(new_team)


### PR DESCRIPTION
## Summary
- fix missing pools blueprint registration in app
- support team creation when members are provided as a list, accepting optional email and phone

## Testing
- `pytest -q`
- `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:5000/api/teams`
- `curl -s -X POST -H "Content-Type: application/json" -d '{"name":"TeamX","members":["a","b"]}' http://127.0.0.1:5000/api/teams -o /tmp/resp.json -w "%{http_code}\n"`
- `cat /tmp/resp.json`


------
https://chatgpt.com/codex/tasks/task_e_689535e54a6c832fb6389e2da9601897